### PR TITLE
SWIK-1061 integrate image service functionality

### DIFF
--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -4,7 +4,10 @@ const boom = require('boom'),
   child = require('child_process'),
   db = require('../database/mediaDatabase'),
   picture = require('./picture'),
-  co = require('../common');
+  co = require('../common'),
+  conf = require('../configuration'),
+  path = require('path'),
+  webshot = require('webshot');
 
 module.exports = {
   storePicture: function(request, reply) {
@@ -37,5 +40,44 @@ module.exports = {
         request.log(err);
         reply(boom.badImplementation(), err);
       });
+  },
+
+  storeThumbnail: (request, response) => {
+    try {
+      let filename = request.payload.slideID;
+      let filepath = path.join(conf.fsPath, 'slidethumbnails/' + filename + '.png'); //TODO implement filename
+      const html = request.payload.html;
+      const options = {
+        screenSize: {
+          width: '1024',
+          height: '900',
+        },
+        shotSize: {
+          width: '1024',
+          height: '900',
+        },
+        shotOffset: {
+          left: 0,
+          top: 0,
+          right: 0,
+          bottom: 0,
+        },
+        timeout: 7000, //in ms
+        siteType: 'html',
+        phantomPath: require('phantomjs2').path // using phantomjs2 instead of what comes with webshot (PS: README of webshot for this)
+      };
+
+      webshot(html, filepath, options, (err) => {
+        if (err){
+          request.log(err);
+          response(boom.badImplementation(), err.message);
+        }
+      });
+      response({'filename': filename});
+    }
+    catch (err) {
+      request.log(err);
+      response(boom.badImplementation(), err);
+    }
   }
 };

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -44,38 +44,29 @@ module.exports = {
 
   storeThumbnail: (request, response) => {
     try {
-      let filename = request.payload.slideID;
-      let filepath = path.join(conf.fsPath, 'slidethumbnails/' + filename + '.png'); //TODO implement filename
-      const html = request.payload.html;
+      const fileName = request.params.slideID;
+      const fileType = '.png';
+      const filePath = path.join(conf.fsPath, 'slideThumbnails/' + fileName + fileType);
+      const html = request.payload;
       const options = {
-        screenSize: {
+        windowSize: {
           width: '1024',
           height: '900',
-        },
-        shotSize: {
-          width: '1024',
-          height: '900',
-        },
-        shotOffset: {
-          left: 0,
-          top: 0,
-          right: 0,
-          bottom: 0,
-        },
+        }, //using many webshot defaults
         timeout: 7000, //in ms
         siteType: 'html',
-        phantomPath: require('phantomjs2').path // using phantomjs2 instead of what comes with webshot (PS: README of webshot for this)
+        phantomPath: require('phantomjs2')
+          .path // using phantomjs2 instead of what comes with webshot (PS: README of webshot for this)
       };
 
-      webshot(html, filepath, options, (err) => {
-        if (err){
+      webshot(html, filePath, options, (err) => {
+        if (err) {
           request.log(err);
           response(boom.badImplementation(), err.message);
-        }
+        } else
+          response({ 'filename': fileName + fileType });
       });
-      response({'filename': filename});
-    }
-    catch (err) {
+    } catch (err) {
       request.log(err);
       response(boom.badImplementation(), err);
     }

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -62,12 +62,14 @@ module.exports = {
       webshot(html, filePath, options, (err) => {
         if (err) {
           request.log(err);
+          request.log(html);
           response(boom.badImplementation(), err.message);
         } else
           response({ 'filename': fileName + fileType });
       });
     } catch (err) {
       request.log(err);
+      request.log(html);
       response(boom.badImplementation(), err);
     }
   }

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -45,14 +45,22 @@ module.exports = {
   storeThumbnail: (request, response) => {
     try {
       const fileName = request.params.slideID;
-      const fileType = '.png';
+      const fileType = '.jpeg';
       const filePath = path.join(conf.fsPath, 'slideThumbnails/' + fileName + fileType);
       const html = request.payload;
       const options = {
         windowSize: {
           width: '1024',
-          height: '900',
-        }, //using many webshot defaults
+          height: '768',
+        },
+        shotOffset: {
+          left: 9,
+          right: 64,
+          top: 9,
+          bottom: 48
+        },
+        defaultWhiteBackground: true,
+        streamType: 'jpeg',
         timeout: 7000, //in ms
         siteType: 'html',
         phantomPath: require('phantomjs2')
@@ -64,8 +72,10 @@ module.exports = {
           request.log(err);
           request.log(html);
           response(boom.badImplementation(), err.message);
-        } else
+        } else{
+          child.execSync('convert ' + filePath + ' -resize 400 ' + filePath);
           response({ 'filename': fileName + fileType });
+        }
       });
     } catch (err) {
       request.log(err);

--- a/application/package.json
+++ b/application/package.json
@@ -40,7 +40,9 @@
     "joi": "^10.2.0",
     "mongodb": "^2.2.22",
     "read-chunk": "^2.0.0",
-    "vision": "^4.1.1"
+    "phantomjs2": "^2.2.0",
+    "vision": "^4.1.1",
+    "webshot": "^0.18.0"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/application/routes.js
+++ b/application/routes.js
@@ -84,6 +84,44 @@ module.exports = function(server) {
 
   server.route({
     method: 'GET',
+    path: '/slideThumbnail/{filename*}',
+    handler: {
+      directory: {
+        path: conf.fsPath + 'slidethumbnails/'
+      }
+    },
+    config: {
+      auth: false,
+      validate: {
+        params: {
+          filename: Joi.string()
+            .trim()
+            .required()
+        },
+      },
+      plugins: {
+        'hapi-swagger': {
+          produces: ['image/jpeg', 'image/png'],
+          responses: {
+            ' 200 ': {
+              'description': 'A pictue is provided'
+            },
+            ' 400 ': {
+              'description': 'Probably a parameter is missing or not allowed'
+            },
+            ' 404 ': {
+              'description': 'No picture was found'
+            }
+          }
+        }
+      },
+      tags: ['api'],
+      description: 'Get a thumbnail by name'
+    }
+  });
+
+  server.route({
+    method: 'GET',
     path: '/metadata/{filename*}',
     handler: handlers.getMetaData,
     config: {
@@ -163,6 +201,35 @@ module.exports = function(server) {
       tags: ['api'],
       description: 'Store a picture'
     },
+  });
+
+  server.route({
+    method: 'POST',
+    path: '/slideThumbnail',
+    handler: handlers.storeThumbnail,
+    config: {
+      validate: {
+        payload: Joi.string().required().description('Actual HTML as string'),
+        query: {
+          slideID: Joi.string().lowercase().trim().required().description('ID of the slide as ID-REVISION')
+        },
+      },
+      plugins: {
+        'hapi-swagger': {
+          consumes: ['text/plain'],
+          responses: {
+            ' 200 ': {
+              'description': 'Successfully processed the HTML and stored a thumbnail, see response',
+            },
+            ' 400 ': {
+              'description': 'Probably a parameter is missing or not allowed'
+            }
+          }
+        }
+      },
+      tags: ['api'],
+      description: 'Create thumbnail of a slide from html'
+    }
   });
 
 };

--- a/application/routes.js
+++ b/application/routes.js
@@ -178,14 +178,14 @@ module.exports = function(server) {
             .description('Caption or Alt text of the picture')
         },
         headers: Joi.object({
-            '----jwt----': Joi.string()
+          '----jwt----': Joi.string()
               .required()
               .description('JWT header provided by the user-service or slidwiki-platform'),
-            'content-type': Joi.string()
+          'content-type': Joi.string()
               .required()
               .valid('image/jpeg', 'image/png', 'image/tiff', 'image/bmp')
               .description('Mime-Type of the uploaded image'), //additinally tested in picture.js on the actual file
-          })
+        })
           .unknown()
       },
       plugins: {

--- a/application/routes.js
+++ b/application/routes.js
@@ -18,7 +18,7 @@ module.exports = function(server) {
       validate: {
         params: {
           filepath: Joi.string()
-            .uri({allowRelative: true})
+            .uri({ allowRelative: true })
             .trim()
             .required()
         },
@@ -84,19 +84,20 @@ module.exports = function(server) {
 
   server.route({
     method: 'GET',
-    path: '/slideThumbnail/{filename*}',
+    path: '/slideThumbnail/{slideID*}',
     handler: {
       directory: {
-        path: conf.fsPath + 'slidethumbnails/'
+        path: conf.fsPath + 'slideThumbnails/'
       }
     },
     config: {
       auth: false,
       validate: {
         params: {
-          filename: Joi.string()
+          slideID: Joi.string()
             .trim()
             .required()
+            .description('ID of the slide as ID-REVISION')
         },
       },
       plugins: {
@@ -168,14 +169,24 @@ module.exports = function(server) {
       validate: {
         payload: Joi.required(),
         query: {
-          license: Joi.string().required().description('Used license (eg. Creative Commons 4.0)'),
-          copyright: Joi.string().description('Exact copyright and copyright holder (e.g. CC-BY-SA SlideWiki user 33)'),
-          title: Joi.string().description('Caption or Alt text of the picture')
+          license: Joi.string()
+            .required()
+            .description('Used license (eg. Creative Commons 4.0)'),
+          copyright: Joi.string()
+            .description('Exact copyright and copyright holder (e.g. CC-BY-SA SlideWiki user 33)'),
+          title: Joi.string()
+            .description('Caption or Alt text of the picture')
         },
         headers: Joi.object({
-          '----jwt----': Joi.string().required().description('JWT header provided by the user-service or slidwiki-platform'),
-          'content-type':  Joi.string().required().valid('image/jpeg', 'image/png', 'image/tiff', 'image/bmp').description('Mime-Type of the uploaded image'),//additinally tested in picture.js on the actual file
-        }).unknown()
+            '----jwt----': Joi.string()
+              .required()
+              .description('JWT header provided by the user-service or slidwiki-platform'),
+            'content-type': Joi.string()
+              .required()
+              .valid('image/jpeg', 'image/png', 'image/tiff', 'image/bmp')
+              .description('Mime-Type of the uploaded image'), //additinally tested in picture.js on the actual file
+          })
+          .unknown()
       },
       plugins: {
         'hapi-swagger': {
@@ -205,13 +216,20 @@ module.exports = function(server) {
 
   server.route({
     method: 'POST',
-    path: '/slideThumbnail',
+    path: '/slideThumbnail/{slideID*}',
     handler: handlers.storeThumbnail,
     config: {
+      auth: false,
       validate: {
-        payload: Joi.string().required().description('Actual HTML as string'),
-        query: {
-          slideID: Joi.string().lowercase().trim().required().description('ID of the slide as ID-REVISION')
+        payload: Joi.string()
+          .required()
+          .description('Actual HTML as string'),
+        params: {
+          slideID: Joi.string()
+            .lowercase()
+            .trim()
+            .required()
+            .description('ID of the slide as ID-REVISION')
         },
       },
       plugins: {

--- a/application/server.js
+++ b/application/server.js
@@ -73,7 +73,7 @@ server.register(plugins, (err) => {
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/pictures');
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/audio');
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/videos');
-      child.execSync('mkdir -p ' + require('./configuration').fsPath + '/slidethumbnails');
+      child.execSync('mkdir -p ' + require('./configuration').fsPath + '/slideThumbnails');
       require('./routes.js')(server);
     });
   }

--- a/application/server.js
+++ b/application/server.js
@@ -73,6 +73,7 @@ server.register(plugins, (err) => {
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/pictures');
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/audio');
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/videos');
+      child.execSync('mkdir -p ' + require('./configuration').fsPath + '/slidethumbnails');
       require('./routes.js')(server);
     });
   }


### PR DESCRIPTION
I've added a folder, route and the functionality to store thumbnails of html and serve the produced images. The API is different from the image-service in order to be consistent with the API of the file-service. I'll change all calls to the thumbnail creation to match the new API.

I've decided against storing metadata in a MongoDB (as I think this has no benefit) and I'm saving thumbnails by slide ID-REV names. The API is publically usable - is this the right approach or should it be private (use JWT authentication)? I've also dropped used-IDs (for folders) as this seems to has no benefit - or am I wrong? Thumbnails are created automatically by the deck-service (thus, no user is involved, right?).