### PR TITLE
Add new error handling for POST /picture to always delete tmp files

### DIFF
--- a/application/package.json
+++ b/application/package.json
@@ -39,6 +39,7 @@
     "image-size": "^0.5.0",
     "inert": "^4.2.0",
     "joi": "^10.6.0",
+    "jsonwebtoken": "^8.1.0",
     "juice": "^4.2.2",
     "mongodb": "^2.2.28",
     "phantomjs2": "^2.2.0",

--- a/application/routes.js
+++ b/application/routes.js
@@ -190,7 +190,8 @@ module.exports = function(server) {
             .valid('image/jpeg', 'image/png', 'image/tiff', 'image/bmp')
             .description('Mime-Type of the uploaded image'), //additinally tested in picture.js on the actual file
         })
-          .unknown()
+          .unknown(),
+        failAction: handlers.storePicture
       },
       plugins: {
         'hapi-swagger': {

--- a/application/routes.js
+++ b/application/routes.js
@@ -179,7 +179,6 @@ module.exports = function(server) {
             .description('Caption of the picture'),
           altText: Joi.string()
             .description('Alt text of the picture'),
-
         },
         headers: Joi.object({
           '----jwt----': Joi.string()
@@ -256,8 +255,8 @@ module.exports = function(server) {
             .required()
             .valid('image/jpeg', 'image/png', 'image/tiff', 'image/bmp')
             .description('Mime-Type of the uploaded image'), //additinally tested in picture.js on the actual file
-        })
-          .unknown()
+        }).unknown(),
+        failAction: handlers.storePicture
       },
       plugins: {
         'hapi-swagger': {
@@ -389,8 +388,8 @@ module.exports = function(server) {
             .required()
             .valid('image/png')
             .description('Mime-Type of the uploaded image')
-        })
-          .unknown()
+        }).unknown(),
+        failAction: handlers.storeProfilepicture
       },
       plugins: {
         'hapi-swagger': {


### PR DESCRIPTION
A simple but effective fix for the undeleted temporary files.
It worked with the error cases the problem was reported for.