### PR TITLE
Fix thumbnail creation (size + themes)

### DIFF
--- a/application/.eslintrc
+++ b/application/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 7,
+    "ecmaVersion": 2017,
     "ecmaFeatures": {
       "blockBindings": true,
       "arrowFunctions": true,

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -11,7 +11,6 @@ const boom = require('boom'),
   puppeteer = require('puppeteer'),
   Joi = require('joi'),
   Microservices = require('../configs/microservices'),
-  juice = require('juice'),
   fs = require('fs'),
   rp = require('request-promise-native');//QUESTION not used?!
 
@@ -218,12 +217,9 @@ function applyThemeToSlideHTML(content, theme){
   <link rel="stylesheet" href="${Microservices.platform.uri}/custom_modules/reveal.js/css/theme/${theme}.css" />
   </head>`;
 
-  let body = '<body><div class="reveal"><div class="slides"><section class="present">' + content + '</section></div></div>'+
-  '<script type="application/javascript">window.myload = true;</script>'+
-  '</body>';
+  let body = '<body><div class="reveal"><div class="slides"><section class="present">' + content + '</section></div></div></body>';
   let html = '<!DOCTYPE html><html>' + head + body + '</html>';
 
-  html = juice(html);
   return html;
 }
 

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -68,7 +68,7 @@ let handlers = module.exports = {
         return response(toReturn);
 
       if (!fs.existsSync(folder))
-          fs.mkdirSync(folder);
+        fs.mkdirSync(folder);
 
       html = applyThemeToSlideHTML(html, theme);
 
@@ -87,14 +87,16 @@ let handlers = module.exports = {
         height = '1080';
       }
 
+      /*eslint-disable promise/always-return*/
       screenshot(html, filePath, width, height)
-      .then( () => {
-        child.execSync('convert ' + filePath + ' -resize 400 ' + filePath);
-        response(toReturn);
-      }).catch((err) => {
-        request.log(err);
-        response(boom.badImplementation(), err.message);
-      });
+        .then( () => {
+          child.execSync('convert ' + filePath + ' -resize 400 ' + filePath);
+          response(toReturn);
+        }).catch((err) => {
+          request.log(err);
+          response(boom.badImplementation(), err.message);
+        });
+      /*eslint-enable promise/always-return*/
 
     } catch (err) {
       request.log(err);
@@ -217,7 +219,7 @@ async function screenshot(html, pathToSaveTo, width, height) {
   let browser = await puppeteer.launch();
   let page = await browser.newPage();
   page.setViewport({width: Number(width), height: Number(height)});
-  page.setJavaScriptEnabled(true)
+  page.setJavaScriptEnabled(true);
 
   // let loaded = page.waitForNavigation({waitUntil: 'domcontentloaded'});
   await page.setContent(html);

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -90,7 +90,7 @@ let handlers = module.exports = {
       /*eslint-disable promise/always-return*/
       screenshot(html, filePath, width, height)
         .then( () => {
-          child.execSync('convert ' + filePath + ' -resize 400 ' + filePath);
+          child.execSync('convert ' + filePath + ' -resize 400 -quality 75 ' + filePath);//NOTE using lower quality to reduce file size, q75 has only minor visual impact
           response(toReturn);
         }).catch((err) => {
           request.log(err);
@@ -225,7 +225,7 @@ async function screenshot(html, pathToSaveTo, width, height) {
   await page.setContent(html);
   // await loaded;//NOTE is not working, that's why a timeout is used TODO find better way
   await page.waitFor(500);
-  await page.screenshot({path: pathToSaveTo, type: 'jpeg'});
+  await page.screenshot({path: pathToSaveTo, type: 'jpeg', quality: 100});//NOTE quality is reduced separately
 
   await browser.close();
 }

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -218,9 +218,7 @@ function applyThemeToSlideHTML(content, theme){
   </head>`;
 
   let body = '<body><div class="reveal"><div class="slides"><section class="present">' + content + '</section></div></div></body>';
-  let html = '<!DOCTYPE html><html>' + head + body + '</html>';
-
-  return html;
+  return '<!DOCTYPE html><html>' + head + body + '</html>';
 }
 
 async function screenshot(html, pathToSaveTo, width, height) {

--- a/application/package.json
+++ b/application/package.json
@@ -40,7 +40,6 @@
     "inert": "^4.2.0",
     "joi": "^10.6.0",
     "jsonwebtoken": "^8.1.0",
-    "juice": "^4.2.2",
     "mongodb": "^2.2.28",
     "puppeteer": "^1.2.0",
     "read-chunk": "^2.0.0",

--- a/application/package.json
+++ b/application/package.json
@@ -42,12 +42,11 @@
     "jsonwebtoken": "^8.1.0",
     "juice": "^4.2.2",
     "mongodb": "^2.2.28",
-    "phantomjs2": "^2.2.0",
+    "puppeteer": "^1.2.0",
     "read-chunk": "^2.0.0",
     "request-promise-native": "^1.0.5",
     "rp": "^0.2.0",
     "vision": "^4.1.0",
-    "webshot": "^0.18.0"
   },
   "engines": {
     "node": ">=6.11.0"

--- a/application/package.json
+++ b/application/package.json
@@ -46,7 +46,7 @@
     "read-chunk": "^2.0.0",
     "request-promise-native": "^1.0.5",
     "rp": "^0.2.0",
-    "vision": "^4.1.0",
+    "vision": "^4.1.0"
   },
   "engines": {
     "node": ">=8.11.0"

--- a/application/server.js
+++ b/application/server.js
@@ -78,3 +78,20 @@ server.register(plugins, (err) => {
     });
   }
 });
+
+function exitHandler(exit = true, cleanup = false) {
+  if(cleanup) {
+    console.log('Stopping puppeteer processes...');
+    require('./controllers/handler').shutDownPuppeteer();
+  }
+  if(exit){
+    console.log('Shutting down...');
+    process.exit();
+  }
+}
+
+process.on('exit', exitHandler.bind(null, false, true));
+process.on('SIGINT', exitHandler);
+process.on('SIGUSR1', exitHandler);
+process.on('SIGUSR2', exitHandler);
+process.on('uncaughtException', exitHandler);


### PR DESCRIPTION
As discussed in slack channel #thumbnailswidescreen , we have a problem with thumbnail creation.

After much digging, I found a solution on using puppeteer (which is used by decktape), that I've implemented as of this branch. The branch is not properly tested yet, but I want to showcase some results and move the discussion here.

For slide 37-8 (default theme):
![37-8](https://user-images.githubusercontent.com/855967/38500991-2a961476-3c0c-11e8-9c23-94236e5a4ac8.jpeg)

For slide 37-8 (black theme):
![37-8](https://user-images.githubusercontent.com/855967/38501032-49f45972-3c0c-11e8-8cda-01c3bacdf716.jpeg)

Is this what is the intended outcome?

Comparison (slide 37-8, old shot):
![37-8](https://user-images.githubusercontent.com/855967/38501056-5f6ee484-3c0c-11e8-9e44-ce0c4b0a343c.jpeg)

This branch is not yet ready to merge.