### PR TITLE
Add SVG graphic support (POST, GET, PUT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,9 +34,11 @@ node_modules
 
 .coveralls.yml
 application/.nyc_output
+package-lock.json
 
 # created files in dev mode
 application/pictures
 application/audio
 application/videos
 application/slideThumbnails
+application/graphics

--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -37,6 +37,24 @@ let handlers = module.exports = {
     }
   },
 
+  updateGraphic: function(request, reply) {
+    if(co.isEmpty(request.payload)){
+      reply(boom.entityTooLarge('Seems like the payload was to large - 10MB max'));
+    } else if (request.payload.bytes <= 1) { //no payload
+      child.execSync('rm -f ' + request.payload.path); //remove tmp file
+      reply(boom.badRequest('A payload is required'));
+    } else {
+      picture.updateGraphic(request)
+        .then((result) => reply(result))
+        .catch((err) => {
+          request.log(err);
+          reply(boom.badImplementation(), err);
+        })
+        .then(() => child.execSync('rm -f ' + request.payload.path))
+        .catch((err) => request.log(err));
+    }
+  },
+
   getMetaData: function(request, reply) {
     db.get(request.params.filename)
       /*eslint-disable promise/always-return*/

--- a/application/controllers/picture.js
+++ b/application/controllers/picture.js
@@ -39,7 +39,7 @@ module.exports = {
           if (co.isEmpty(result)){
             return processPicture(request, sum, fileExtension);
           } else
-            return boom.conflict('File already exists and is stored under ' + sum + fileExtension, result);
+            return boom.conflict('File already exists and is stored under ' + ((fileExtension === '.svg') ? '/graphic/' : '') + sum + fileExtension, result);
         });
     } catch (err) {
       request.log(err);

--- a/application/controllers/picture.js
+++ b/application/controllers/picture.js
@@ -7,27 +7,64 @@ const boom = require('boom'),
   sizeOf = require('image-size'),
   db = require('../database/mediaDatabase'),
   readChunk = require('read-chunk'),
-  fileType = require('file-type');
+  fileType = require('file-type'),
+  is_svg = require('is-svg'),
+  fs = require('fs');
 
 module.exports = {
   searchPictureAndProcess: function(request) {
     try {
+      let isSVG = false;
       let buffer = readChunk.sync(request.payload.path, 0, 262);
-      if(!['image/jpeg', 'image/png', 'image/tiff', 'image/bmp'].includes(!co.isEmpty(fileType(buffer)) ? fileType(buffer).mime : null))
-        return new Promise((resolve, reject) => resolve(boom.unsupportedMediaType()));
-      let hasAlpha = child.execSync('identify -format "%[channels]" ' + request.payload.path)
-        .toString()
-        .includes('a');
-      let fileExtension = hasAlpha ? '.png' : '.jpg';
+      if(!['image/jpeg', 'image/png', 'image/tiff', 'image/bmp'].includes(!co.isEmpty(fileType(buffer)) ? fileType(buffer).mime : null)){
+        //NOTE check for svg as file-type can't check for svg
+        let fileContent = fs.readFileSync(request.payload.path, {encoding: 'utf8'});
+        isSVG = is_svg(fileContent);
+        if(!isSVG)
+          return new Promise((resolve, reject) => resolve(boom.unsupportedMediaType()));
+      }
+      let fileExtension;
+      if(!isSVG){
+        let hasAlpha = child.execSync('identify -format "%[channels]" ' + request.payload.path)
+          .toString()
+          .includes('a');
+        fileExtension = hasAlpha ? '.png' : '.jpg';
+      } else
+        fileExtension = '.svg';
       let sum = child.execSync('sha256sum ' + request.payload.path)
         .toString()
         .split(' ')[0];
       return db.get(sum + fileExtension)
         .then((result) => {
-          if (co.isEmpty(result))
+          if (co.isEmpty(result)){
             return processPicture(request, sum, fileExtension);
-          else
+          } else
             return boom.conflict('File already exists and is stored under ' + sum + fileExtension, result);
+        });
+    } catch (err) {
+      request.log(err);
+      return new Promise((resolve, reject) => resolve(boom.badImplementation()));
+    }
+  },
+
+  updateGraphic: function(request) {
+    try {
+      let fileContent = fs.readFileSync(request.payload.path, {encoding: 'utf8'});
+      let isSVG = is_svg(fileContent);
+      if(!isSVG)
+        return new Promise((resolve, reject) => resolve(boom.unsupportedMediaType()));
+      let fileExtension = '.svg';
+      let sum = request.params.filename.split('.')[0];
+      return db.get(sum + fileExtension, true)
+        .then((result) => {
+          if (co.isEmpty(result)){
+            return boom.NotFound();
+          } else {
+            if(request.auth.credentials.userid === result.owner)
+              return processGraphicUpdate(request, sum, fileExtension, result);
+            else
+              return boom.unauthorized();
+          }
         });
     } catch (err) {
       request.log(err);
@@ -50,11 +87,41 @@ module.exports = {
   }
 };
 
+function processGraphicUpdate(request, sum, fileExtension, dbEntry) {
+  try{
+    child.execSync('mv ' + request.payload.path + ' ' + conf.fsPath + '/graphics/' + sum + fileExtension);
+    let targetPath = conf.fsPath + 'graphics/';
+    let title = (request.query.title) ? request.query.title : ((dbEntry.title) ? dbEntry.title : '');
+    let altText = (request.query.altText) ? request.query.altText : ((dbEntry.altText) ? dbEntry.altText : '');
+    let copyrightHolder = (dbEntry.copyrightHolder) ? dbEntry.copyrightHolder.name : undefined;
+    let copyrightHolderURL = (dbEntry.copyrightHolder) ? dbEntry.copyrightHolder.URL : undefined;
+    let file = createMediaObject(targetPath, sum, fileExtension, dbEntry.owner, title, altText, dbEntry.license, copyrightHolder, copyrightHolderURL, dbEntry.copyrightAdditions);
+    file._id = dbEntry._id;
+    return db.update(file)
+      .then((result) => {
+        if (!co.isEmpty(result[0]))
+          return boom.badData('File storage failed because data is wrong: ', co.parseAjvValidationErrors(result));
+        else
+          return file;
+      });
+  } catch (err) {
+    request.log(err);
+    return boom.badImplementation();
+  }
+}
+
 function processPicture(request, sum, fileExtension) {
   try {
-    optimizePictures(request.payload.path, fileExtension, sum);
-    child.execSync('mv ' + conf.tmp + '/' + sum + '* ' + conf.fsPath + '/pictures/');
-    let file = createMediaObject(conf.fsPath + 'pictures/', sum, fileExtension, request.auth.credentials.userid, request.query.title, request.query.altText, request.query.license, request.query.copyrightHolder, request.query.copyrightHolderURL, request.query.copyrightAdditions, request.query.copyright);
+    let targetPath = '';
+    if( fileExtension !== '.svg' ){
+      optimizePictures(request.payload.path, fileExtension, sum);
+      child.execSync('mv ' + conf.tmp + '/' + sum + '* ' + conf.fsPath + '/pictures/');
+      targetPath = conf.fsPath + 'pictures/';
+    } else {
+      child.execSync('mv ' + request.payload.path + ' ' + conf.fsPath + '/graphics/' + sum + fileExtension);
+      targetPath = conf.fsPath + 'graphics/';
+    }
+    let file = createMediaObject(targetPath, sum, fileExtension, request.auth.credentials.userid, request.query.title, request.query.altText, request.query.license, request.query.copyrightHolder, request.query.copyrightHolderURL, request.query.copyrightAdditions, request.query.copyright);
     return db.insert(file)
       .then((result) => {
         if (!co.isEmpty(result[0]))
@@ -103,12 +170,12 @@ function createMediaObject(path, sum, fileExtension, owner, newTitle, altText, l
   let result = {
     type: mimeType,
     fileName: sum + fileExtension,
-    thumbnailName: sum + '_thumbnail' + fileExtension,
     owner: owner,
     license: license,
     metadata: metaObject
   };
   //optional values
+  if(mimeType !== 'image/svg+xml') result.thumbnailName = sum + '_thumbnail' + fileExtension;
   if(!co.isEmpty(title)) result.title = title;
   if(!co.isEmpty(altText)) result.altText = altText;
   if(!co.isEmpty(copyrightHolder)) result.copyrightHolder = { name: copyrightHolder};

--- a/application/database/mediaDatabase.js
+++ b/application/database/mediaDatabase.js
@@ -4,10 +4,15 @@ const helper = require('./helper'),
   mediaModel = require('../models/media.js');
 
 module.exports = {
-  get: function(filename) {
+  get: function(filename, includeID = false) {
     return helper.connectToDatabase()
       .then((db) => db.collection('media'))
-      .then((col) => col.findOne({ $or: [{ fileName: filename }, { thumbnailName: filename }] }, { _id: 0 }));
+      .then((col) => {
+        if(includeID)
+          return col.findOne({ $or: [{ fileName: filename }, { thumbnailName: filename }] });
+        else
+          return col.findOne({ $or: [{ fileName: filename }, { thumbnailName: filename }] }, { _id: 0 });
+      });
   },
 
   insert: function(media) {
@@ -18,6 +23,22 @@ module.exports = {
           if (!mediaModel(media))
             return mediaModel.errors;
           return col.insertOne(media);
+        } catch (e) {
+          console.log('validation failed', e);
+          return e;
+        }
+      });
+  },
+
+  update: function(media) {
+    console.log(media);
+    return helper.connectToDatabase()
+      .then((db) => db.collection('media'))
+      .then((col) => {
+        try {
+          if (!mediaModel(media))
+            return mediaModel.errors;
+          return col.updateOne({'_id': media._id}, {$set: {title: media.title, altText: media.altText, metadata: media.metadata}});
         } catch (e) {
           console.log('validation failed', e);
           return e;

--- a/application/models/media.js
+++ b/application/models/media.js
@@ -8,11 +8,6 @@ let ajv = Ajv({
 const media = {
   type: 'object',
   properties: {
-    _id: {
-      type: 'string',
-      maxLength: 24,
-      minLength: 24
-    },
     title: {
       type: 'string'
     },
@@ -21,7 +16,7 @@ const media = {
     },
     type: {
       type: 'string',
-      enum: ['image/jpeg', 'image/png', 'audio/ogg', 'audio/mp3', 'audio/opus', 'video/h264', 'video/h265']
+      enum: ['image/jpeg', 'image/png', 'image/svg+xml', 'audio/ogg', 'audio/mp3', 'audio/opus', 'video/h264', 'video/h265']
     },
     fileName: {
       type: 'string'

--- a/application/package.json
+++ b/application/package.json
@@ -39,6 +39,7 @@
     "hapi-swagger": "^7.6.0",
     "image-size": "^0.5.0",
     "inert": "^4.2.0",
+    "is-svg": "^3.0.0",
     "joi": "^10.6.0",
     "jsonwebtoken": "^8.1.0",
     "mongodb": "^2.2.28",

--- a/application/server.js
+++ b/application/server.js
@@ -71,6 +71,7 @@ server.register(plugins, (err) => {
       server.log('info', 'Server started at ' + server.info.uri);
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/pictures');
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/pictures/profile');
+      child.execSync('mkdir -p ' + require('./configuration').fsPath + '/graphics');
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/audio');
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/videos');
       child.execSync('mkdir -p ' + require('./configuration').fsPath + '/slideThumbnails');


### PR DESCRIPTION
This adds SVG support to the file service. SVGs are uploaded via /v2/picture, retrieved via /graphics/{*filename} and updated via &graphics/{*filename}. Updating is restricted to the owner of the file.

Some example requests:
```
curl -i -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header '----jwt----: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VyaWQiOjMzLCJ1c2VybmFtZSI6InJtZWlzc24iLCJlbWFpbCI6InJveW1laXNzbkBnbWFpbC5jb20iLCJpc1Jldmlld2VyIjpmYWxzZSwiaWF0IjoxNTMxODE1MjA5fQ.CTUxXcVMWggjlT8idHxFwnJZR3MO_WeTLf4AE2KPKE0VX-GKEBnSdEXHtLDBYgsFyIbctMpbO27nVROctNe2nA' --header 'content-type: image/svg+xml' -d @/home/rmeissner/Downloads/test.svg 'http://localhost:3000/v2/picture?title=test&altText=test&license=CC%20BY-SA%204.0&copyrightHolder=test&copyrightAdditions=test'

curl -i -X PUT --header 'Content-Type: application/json' --header 'Accept: application/json' --header '----jwt----: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1c2VyaWQiOjMzLCJ1c2VybmFtZSI6InJtZWlzc24iLCJlbWFpbCI6InJveW1laXNzbkBnbWFpbC5jb20iLCJpc1Jldmlld2VyIjpmYWxzZSwiaWF0IjoxNTMxODE1MjA5fQ.CTUxXcVMWggjlT8idHxFwnJZR3MO_WeTLf4AE2KPKE0VX-GKEBnSdEXHtLDBYgsFyIbctMpbO27nVROctNe2nA' --header 'content-type: image/svg+xml' -d @/home/rmeissner/Downloads/test2.svg 'http://localhost:3000/graphic/170f6d52ebda3839f2121ebf5f64b80b7f680283a96acf5e2c9b02a9a3af9220.svg?title=test2&altText=test2'

curl -X GET --header 'Accept: application/json' 'http://localhost:3000/metadata/170f6d52ebda3839f2121ebf5f64b80b7f680283a96acf5e2c9b02a9a3af9220.svg'

```

@sednanref Please have a look at the API and verify that it is usable for you.

@TBoonX Please review this code