### PR TITLE
SWIK-2291 Remove thin white line on slide thumbnails

### DIFF
--- a/application/controllers/handler.js
+++ b/application/controllers/handler.js
@@ -429,7 +429,7 @@ async function getPictureFromSlide(pathToSaveTo, html, theme = 'default', thumbn
 
   await screenshot(html, pathToSaveTo, width, height);
   if(thumbnail)
-    child.execSync('convert ' + pathToSaveTo + ' -resize 400 -quality 75 ' + pathToSaveTo);//NOTE using lower quality to reduce file size, q75 has only minor visual impact
+    child.execSync('convert ' + pathToSaveTo + ' -crop +8+8 -resize 400 -quality 75 ' + pathToSaveTo);//NOTE using lower quality to reduce file size, q75 has only minor visual impact
   return pathToSaveTo;
 }
 


### PR DESCRIPTION
It seems like **all** slide thumbnails had a white padding of 8x8x0x0 (LxTxRxB) px. I'm now cropping the created images to remove this padding from slide thumbnails.
May be tested with slides 37645-3 and 41078-2 or any other slide containing a full slide background or text moved to the left/top edge of the slide.